### PR TITLE
Add support for magnet link creation

### DIFF
--- a/pico-torrent.py
+++ b/pico-torrent.py
@@ -30,7 +30,8 @@ import argparse, os
 
 
 argument = argparse.ArgumentParser()
-argument.add_argument("--file", "-f",
+exclusive = argument.add_mutually_exclusive_group(required=True)
+exclusive.add_argument("--file", "-f",
                        help="Torrent file or magnet link to download")
 argument.add_argument("--seeding", "-S", action="store_true",
                        help="Keep seeding after the download is complete")
@@ -40,7 +41,7 @@ argument.add_argument("--output", "-O", action="store_true",
                        help="File output; filename")
 #argument.add_argument("--download-priority", "-P", default=lt.pri,
 #                       help="Set download priority")
-argument.add_argument("--link", "-L",
+exclusive.add_argument("--link", "-L",
                        help="Create a magnet link through a file")
 argument.add_argument("--dir", "-d",
 					   help="Specify the download save directory")

--- a/pico-torrent.py
+++ b/pico-torrent.py
@@ -30,7 +30,7 @@ import argparse, os
 
 
 argument = argparse.ArgumentParser()
-argument.add_argument("--file", "-f", required=True,
+argument.add_argument("--file", "-f",
                        help="Torrent file or magnet link to download")
 argument.add_argument("--seeding", "-S", action="store_true",
                        help="Keep seeding after the download is complete")
@@ -40,8 +40,8 @@ argument.add_argument("--output", "-O", action="store_true",
                        help="File output; filename")
 #argument.add_argument("--download-priority", "-P", default=lt.pri,
 #                       help="Set download priority")
-#argument.add_argument("--link", "-L",
-#                       help="Create a magnet link through a file")
+argument.add_argument("--link", "-L",
+                       help="Create a magnet link through a file")
 argument.add_argument("--dir", "-d",
 					   help="Specify the download save directory")
 arguments = argument.parse_args()
@@ -87,4 +87,12 @@ def start_download(filename):
     except Exception as error:
         print(">>> There was an error: {}".format(error))
 
-start_download(arguments.file)
+
+def create_magnet(filename):
+    return lt.make_magnet_uri(lt.torrent_info(filename))
+
+
+if arguments.link:
+    print(create_magnet(arguments.link))
+elif arguments.file:
+    start_download(arguments.file)


### PR DESCRIPTION
Implements --link/-L using the following syntax:
python3.? pico-torrent -L file
--file/-f and --link/-L cannot be used together